### PR TITLE
fix: use absolute $HOME paths in home::symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,15 @@ TODO: Add a short summary of this module.
 
 - `p6df::modules::terraform::aliases::init(_module, dir)`
   - Args:
-    - _module - 
-    - dir - 
+    - _module -
+    - dir -
 - `p6df::modules::terraform::deps()`
 - `p6df::modules::terraform::external::brew()`
 - `p6df::modules::terraform::home::symlink()`
 - `p6df::modules::terraform::init(_module, dir)`
   - Args:
-    - _module - 
-    - dir - 
+    - _module -
+    - dir -
 - `p6df::modules::terraform::vscodes()`
 - `p6df::modules::terraform::vscodes::config()`
 - `str str = p6df::modules::terraform::prompt::mod()`
@@ -70,14 +70,14 @@ TODO: Add a short summary of this module.
 - `p6df::modules::terraform::cli::validate()`
 - `str workspace = p6df::modules::terraform::cli::workspace::select(workspace)`
   - Args:
-    - workspace - 
+    - workspace -
 - `str ws = p6df::modules::terraform::cli::workspace::show()`
 
 ##### p6df-terraform/lib/cmd.sh
 
 - `p6df::modules::terraform::cmd(...)`
   - Args:
-    - ... - 
+    - ... -
 
 ##### p6df-terraform/lib/util.sh
 

--- a/init.zsh
+++ b/init.zsh
@@ -63,7 +63,7 @@ EOF
 ######################################################################
 p6df::modules::terraform::home::symlink() {
 
-    p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-terraform/share/.terraform.d" ".terraform.d"
+    p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-terraform/share/.terraform.d" "$HOME/.terraform.d"
 
     p6_return_void
 }


### PR DESCRIPTION
Symlink targets were using relative paths (e.g. `.aws`) instead of absolute `$HOME/.aws`. Fixes symlinks when not run from $HOME.