### PR TITLE
feat: add mcp() hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@
 
 ## Summary
 
-TODO: Add a short summary of this module.
+p6df module for Terraform/OpenTofu: CLI tools, workspace management, VSCode
+extensions, and MCP server (`terraform-mcp-server` via brew) for AI-driven
+infrastructure provisioning and resource management.
 
 ## Contributing
 
@@ -33,8 +35,8 @@ TODO: Add a short summary of this module.
 ### Aliases
 
 - `tfsl` -> `p6df::modules::terraform::cli::state::list`
-- `tfws` -> `p6df::modules::terraform::cli::workspace::show`
 - `tfwS` -> `p6df::modules::terraform::cli::workspace::select`
+- `tfws` -> `p6df::modules::terraform::cli::workspace::show`
 
 ### Functions
 
@@ -44,15 +46,16 @@ TODO: Add a short summary of this module.
 
 - `p6df::modules::terraform::aliases::init(_module, dir)`
   - Args:
-    - _module -
-    - dir -
+    - _module
+    - dir
 - `p6df::modules::terraform::deps()`
 - `p6df::modules::terraform::external::brew()`
 - `p6df::modules::terraform::home::symlink()`
 - `p6df::modules::terraform::init(_module, dir)`
   - Args:
-    - _module -
-    - dir -
+    - _module
+    - dir
+- `p6df::modules::terraform::mcp()`
 - `p6df::modules::terraform::vscodes()`
 - `p6df::modules::terraform::vscodes::config()`
 - `str str = p6df::modules::terraform::prompt::mod()`
@@ -70,14 +73,14 @@ TODO: Add a short summary of this module.
 - `p6df::modules::terraform::cli::validate()`
 - `str workspace = p6df::modules::terraform::cli::workspace::select(workspace)`
   - Args:
-    - workspace -
+    - workspace
 - `str ws = p6df::modules::terraform::cli::workspace::show()`
 
 ##### p6df-terraform/lib/cmd.sh
 
 - `p6df::modules::terraform::cmd(...)`
   - Args:
-    - ... -
+    - ...
 
 ##### p6df-terraform/lib/util.sh
 

--- a/init.zsh
+++ b/init.zsh
@@ -16,7 +16,7 @@ p6df::modules::terraform::deps() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::opentofu::vscodes()
+# Function: p6df::modules::terraform::vscodes()
 #
 #>
 ######################################################################
@@ -31,7 +31,7 @@ p6df::modules::terraform::vscodes() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::opentofu::vscodes::config()
+# Function: p6df::modules::terraform::vscodes::config()
 #
 #>
 ######################################################################
@@ -58,7 +58,7 @@ EOF
 #
 # Function: p6df::modules::terraform::home::symlink()
 #
-#  Environment:	 P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
 ######################################################################
 p6df::modules::terraform::home::symlink() {
@@ -128,6 +128,7 @@ p6df::modules::terraform::aliases::init() {
 #	_module -
 #	dir -
 #
+#  Environment:	 TERRAFORM_BINARY_NAME
 #>
 ######################################################################
 p6df::modules::terraform::init() {
@@ -185,4 +186,18 @@ p6_terraform_version() {
   fi
 
   p6_return_str "$ver"
+}
+
+######################################################################
+#<
+#
+# Function: p6df::modules::terraform::mcp()
+#
+#>
+######################################################################
+p6df::modules::terraform::mcp() {
+
+  p6df::core::homebrew::cli::brew::install terraform-mcp-server
+
+  p6_return_void
 }


### PR DESCRIPTION
## Summary

- Add `mcp()` hook: installs `terraform-mcp-server` via brew (HashiCorp's official MCP server) for AI-driven Terraform/OpenTofu infrastructure management via MCP

## Test plan

- [ ] `p6df mcp` installs `terraform-mcp-server` via brew

🤖 Generated with [Claude Code](https://claude.com/claude-code)