### PR TITLE
fix: rename external::brew() -> external::brews() to match framework dispatch

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -75,11 +75,11 @@ p6df::modules::terraform::home::symlink() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::terraform::external::brew()
+# Function: p6df::modules::terraform::external::brews()
 #
 #>
 ######################################################################
-p6df::modules::terraform::external::brew() {
+p6df::modules::terraform::external::brews() {
 
     p6df::core::homebrew::cli::brew::install opentofu
 #    p6df::core::homebrew::cli::brew::install hashicorp/tap/terraform


### PR DESCRIPTION
## Summary
- Rename `external::brew()` → `external::brews()` to match the plural form dispatched by `p6df-core/lib/module.zsh`

## Test plan
- [ ] Verify `p6df::core::module::brews` dispatch resolves correctly