### PR TITLE
chore(terraform): rename home::symlink to home::symlinks, add credential ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 share/.terraform.d/plugin-cache
 share/.terraform.d/checkpoint_cache
+share/.terraform.d/credentials.tfrc.json
+share/.terraform.d/checkpoint_signature

--- a/init.zsh
+++ b/init.zsh
@@ -60,12 +60,12 @@ EOF
 ######################################################################
 #<
 #
-# Function: p6df::modules::terraform::home::symlink()
+# Function: p6df::modules::terraform::home::symlinks()
 #
 #  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
 ######################################################################
-p6df::modules::terraform::home::symlink() {
+p6df::modules::terraform::home::symlinks() {
 
     p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-terraform/share/.terraform.d" "$HOME/.terraform.d"
 


### PR DESCRIPTION
## What
Rename `home::symlink` (singular) to `home::symlinks` (plural). Add credentials.tfrc.json and checkpoint_signature to .gitignore.

## Why
The p6df-core framework dispatches `home::symlinks` (plural) via `p6df::core::internal::recurse`. The singular function was never auto-called. credentials.tfrc.json contains Terraform Cloud tokens and must not be tracked.

## Test plan
- `p6df home symlinks` recreates ~/.terraform.d
- `git check-ignore share/.terraform.d/credentials.tfrc.json` confirms it is ignored

## Dependencies
None