### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::terraform::deps()
-#
-#>
-######################################################################
 p6df::modules::terraform::deps() {
     ModuleDeps=(
         p6m7g8-dotfiles/p6df-go
@@ -18,11 +12,68 @@ p6df::modules::terraform::deps() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::terraform::vscodes()
-#
-#>
+p6df::modules::terraform::env::init() {
+
+  local _module="$1"
+  local _dir="$2"
+  p6_env_export "TERRAFORM_BINARY_NAME" "tofu"
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::terraform::aliases::init() {
+    local _module="$1"
+    local dir="$2"
+
+    p6_alias "tf"   "p6df::modules::terraform::cmd"
+    p6_alias "tfa"  "p6df::modules::terraform::cli::apply"
+    p6_alias "tfc"  "p6df::modules::terraform::cli::console"
+    p6_alias "tfd"  "p6df::modules::terraform::cli::destroy"
+    p6_alias "tfp"  "p6df::modules::terraform::cli::plan"
+    p6_alias "tfsl" "p6df::modules::terraform::cli::state::list"
+    p6_alias "tfv"  "p6df::modules::terraform::cli::validate"
+    p6_alias "tfwS" "p6df::modules::terraform::cli::workspace::select"
+    p6_alias "tfws" "p6df::modules::terraform::cli::workspace::show"
+
+    p6_return_void
+}
+
+######################################################################
+p6df::modules::terraform::home::symlinks() {
+
+    p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-terraform/share/.terraform.d" "$HOME/.terraform.d"
+
+    p6_return_void
+}
+
+######################################################################
+p6df::modules::terraform::external::brews() {
+
+    p6df::core::homebrew::cli::brew::install opentofu
+#    p6df::core::homebrew::cli::brew::install hashicorp/tap/terraform
+
+    p6df::core::homebrew::cli::brew::install terraform-inventory
+    p6df::core::homebrew::cli::brew::install terraform-docs
+    p6df::core::homebrew::cli::brew::install terraform_landscape
+    p6df::core::homebrew::cli::brew::install terraformer
+    p6df::core::homebrew::cli::brew::install terraform-ls
+    p6df::core::homebrew::cli::brew::install iam-policy-json-to-terraform
+
+    p6_return_void
+}
+
+######################################################################
+p6df::modules::terraform::mcp() {
+
+  p6df::core::homebrew::cli::brew::install terraform-mcp-server
+
+  p6df::modules::anthropic::mcp::server::add "terraform" "terraform-mcp-server"
+  p6df::modules::openai::mcp::server::add "terraform" "terraform-mcp-server"
+
+  p6_return_void
+}
+
 ######################################################################
 p6df::modules::terraform::vscodes() {
 
@@ -32,12 +83,6 @@ p6df::modules::terraform::vscodes() {
     p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::terraform::vscodes::config()
-#
-#>
 ######################################################################
 p6df::modules::terraform::vscodes::config() {
 
@@ -60,40 +105,34 @@ EOF
 ######################################################################
 #<
 #
+# Function: p6df::modules::terraform::deps()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::terraform::vscodes()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::terraform::vscodes::config()
+#
+#>
+######################################################################
+#<
+#
 # Function: p6df::modules::terraform::home::symlinks()
 #
 #  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
-######################################################################
-p6df::modules::terraform::home::symlinks() {
-
-    p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-terraform/share/.terraform.d" "$HOME/.terraform.d"
-
-    p6_return_void
-}
-
 ######################################################################
 #<
 #
 # Function: p6df::modules::terraform::external::brews()
 #
 #>
-######################################################################
-p6df::modules::terraform::external::brews() {
-
-    p6df::core::homebrew::cli::brew::install opentofu
-#    p6df::core::homebrew::cli::brew::install hashicorp/tap/terraform
-
-    p6df::core::homebrew::cli::brew::install terraform-inventory
-    p6df::core::homebrew::cli::brew::install terraform-docs
-    p6df::core::homebrew::cli::brew::install terraform_landscape
-    p6df::core::homebrew::cli::brew::install terraformer
-    p6df::core::homebrew::cli::brew::install terraform-ls
-    p6df::core::homebrew::cli::brew::install iam-policy-json-to-terraform
-
-    p6_return_void
-}
-
 ######################################################################
 #<
 #
@@ -105,40 +144,12 @@ p6df::modules::terraform::external::brews() {
 #
 #>
 ######################################################################
-p6df::modules::terraform::aliases::init() {
-    local _module="$1"
-    local dir="$2"
-
-    p6_alias "tf"   "p6df::modules::terraform::cmd"
-    p6_alias "tfa"  "p6df::modules::terraform::cli::apply"
-    p6_alias "tfc"  "p6df::modules::terraform::cli::console"
-    p6_alias "tfd"  "p6df::modules::terraform::cli::destroy"
-    p6_alias "tfp"  "p6df::modules::terraform::cli::plan"
-    p6_alias "tfsl" "p6df::modules::terraform::cli::state::list"
-    p6_alias "tfv"  "p6df::modules::terraform::cli::validate"
-    p6_alias "tfwS" "p6df::modules::terraform::cli::workspace::select"
-    p6_alias "tfws" "p6df::modules::terraform::cli::workspace::show"
-
-    p6_return_void
-}
-
-######################################################################
 #<
 #
 # Function: p6df::modules::terraform::env::init()
 #
 #  Environment:	 TERRAFORM_BINARY_NAME
 #>
-######################################################################
-p6df::modules::terraform::env::init() {
-
-  local _module="$1"
-  local _dir="$2"
-  p6_env_export "TERRAFORM_BINARY_NAME" "tofu"
-
-  p6_return_void
-}
-
 ######################################################################
 #<
 #
@@ -191,14 +202,3 @@ p6_terraform_version() {
 # Function: p6df::modules::terraform::mcp()
 #
 #>
-######################################################################
-p6df::modules::terraform::mcp() {
-
-  p6df::core::homebrew::cli::brew::install terraform-mcp-server
-
-  p6df::modules::anthropic::mcp::server::add "terraform" "terraform-mcp-server"
-  p6df::modules::openai::mcp::server::add "terraform" "terraform-mcp-server"
-
-  p6_return_void
-}
-

--- a/init.zsh
+++ b/init.zsh
@@ -1,5 +1,11 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::terraform::deps()
+#
+#>
+######################################################################
 p6df::modules::terraform::deps() {
     ModuleDeps=(
         p6m7g8-dotfiles/p6df-go
@@ -12,6 +18,13 @@ p6df::modules::terraform::deps() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::terraform::env::init()
+#
+#  Environment:	 TERRAFORM_BINARY_NAME
+#>
+######################################################################
 p6df::modules::terraform::env::init() {
 
   local _module="$1"
@@ -21,6 +34,16 @@ p6df::modules::terraform::env::init() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::terraform::aliases::init(_module, dir)
+#
+#  Args:
+#	_module -
+#	dir -
+#
+#>
 ######################################################################
 p6df::modules::terraform::aliases::init() {
     local _module="$1"
@@ -40,6 +63,13 @@ p6df::modules::terraform::aliases::init() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::terraform::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#>
+######################################################################
 p6df::modules::terraform::home::symlinks() {
 
     p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-terraform/share/.terraform.d" "$HOME/.terraform.d"
@@ -47,6 +77,12 @@ p6df::modules::terraform::home::symlinks() {
     p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::terraform::external::brews()
+#
+#>
 ######################################################################
 p6df::modules::terraform::external::brews() {
 
@@ -64,6 +100,12 @@ p6df::modules::terraform::external::brews() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::terraform::mcp()
+#
+#>
+######################################################################
 p6df::modules::terraform::mcp() {
 
   p6df::core::homebrew::cli::brew::install terraform-mcp-server
@@ -75,6 +117,12 @@ p6df::modules::terraform::mcp() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::terraform::vscodes()
+#
+#>
+######################################################################
 p6df::modules::terraform::vscodes() {
 
     p6df::modules::vscode::extension::install opentofu.vscode-opentofu
@@ -83,6 +131,12 @@ p6df::modules::terraform::vscodes() {
     p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::terraform::vscodes::config()
+#
+#>
 ######################################################################
 p6df::modules::terraform::vscodes::config() {
 
@@ -102,54 +156,6 @@ EOF
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::terraform::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::terraform::vscodes()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::terraform::vscodes::config()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::terraform::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::terraform::external::brews()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::terraform::aliases::init(_module, dir)
-#
-#  Args:
-#	_module -
-#	dir -
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::terraform::env::init()
-#
-#  Environment:	 TERRAFORM_BINARY_NAME
-#>
 ######################################################################
 #<
 #
@@ -196,9 +202,3 @@ p6_terraform_version() {
   p6_return_str "$ver"
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::terraform::mcp()
-#
-#>


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None