### PR TITLE
feat(terraform): add version lib helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@
 
 ## Summary
 
-p6df module for Terraform/OpenTofu: CLI tools, workspace management, VSCode
-extensions, and MCP server (`terraform-mcp-server` via brew) for AI-driven
-infrastructure provisioning and resource management.
+TODO: Add a short summary of this module.
 
 ## Contributing
 
@@ -49,17 +47,16 @@ infrastructure provisioning and resource management.
     - _module
     - dir
 - `p6df::modules::terraform::deps()`
-- `p6df::modules::terraform::external::brew()`
-- `p6df::modules::terraform::home::symlink()`
-- `p6df::modules::terraform::init(_module, dir)`
+- `p6df::modules::terraform::env::init(_module, _dir)`
   - Args:
     - _module
-    - dir
+    - _dir
+- `p6df::modules::terraform::external::brews()`
+- `p6df::modules::terraform::home::symlinks()`
 - `p6df::modules::terraform::mcp()`
 - `p6df::modules::terraform::vscodes()`
 - `p6df::modules::terraform::vscodes::config()`
-- `str str = p6df::modules::terraform::prompt::mod()`
-- `str ver = p6_terraform_version()`
+- `str str = p6df::modules::terraform::prompt::context()`
 
 #### p6df-terraform/lib
 
@@ -86,6 +83,10 @@ infrastructure provisioning and resource management.
 
 - `path tfvar_file_path = p6df::modules::terraform::util::tfvar::file()`
 
+##### p6df-terraform/lib/version.zsh
+
+- `str ver = p6_terraform_version()`
+
 ## Hierarchy
 
 ```text
@@ -94,11 +95,12 @@ infrastructure provisioning and resource management.
 ├── lib
 │   ├── cli.sh
 │   ├── cmd.sh
-│   └── util.sh
+│   ├── util.sh
+│   └── version.zsh
 ├── README.md
 └── share
 
-3 directories, 5 files
+3 directories, 6 files
 ```
 
 ## Author

--- a/init.zsh
+++ b/init.zsh
@@ -20,7 +20,11 @@ p6df::modules::terraform::deps() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::terraform::env::init()
+# Function: p6df::modules::terraform::env::init(_module, _dir)
+#
+#  Args:
+#	_module -
+#	_dir -
 #
 #  Environment:	 TERRAFORM_BINARY_NAME
 #>
@@ -179,26 +183,4 @@ p6df::modules::terraform::prompt::context() {
     p6_return_str "$str"
 }
 
-######################################################################
-#<
-#
-# Function: str ver = p6_terraform_version()
-#
-#  Returns:
-#	str - ver
-#
-#  Environment:	 TERRAFORM_BINARY_NAME
-#>
-######################################################################
-p6_terraform_version() {
-
-  local ver
-  if p6_string_eq "tofu" "$TERRAFORM_BINARY_NAME"; then
-    ver=$(tofu --version | p6_filter_row_first 1 | p6_filter_column_pluck 2)
-  else
-    ver=$(terraform --version | p6_filter_row_first 1 | p6_filter_column_pluck 2)
-  fi
-
-  p6_return_str "$ver"
-}
 

--- a/lib/version.zsh
+++ b/lib/version.zsh
@@ -1,0 +1,23 @@
+# shellcheck shell=bash
+######################################################################
+#<
+#
+# Function: str ver = p6_terraform_version()
+#
+#  Returns:
+#	str - ver
+#
+#  Environment:	 TERRAFORM_BINARY_NAME
+#>
+######################################################################
+p6_terraform_version() {
+
+  local ver
+  if p6_string_eq "tofu" "$TERRAFORM_BINARY_NAME"; then
+    ver=$(tofu --version | p6_filter_row_first 1 | p6_filter_column_pluck 2)
+  else
+    ver=$(terraform --version | p6_filter_row_first 1 | p6_filter_column_pluck 2)
+  fi
+
+  p6_return_str "$ver"
+}


### PR DESCRIPTION
**What:** Add `lib/version.zsh` helper and update `init.zsh` to source it.

**Why:** Extracts version-related Terraform helpers into a dedicated lib module for better organization and reuse.

**Test plan:** Source the module in a zsh session and verify version functions are available.

**Dependencies:** none